### PR TITLE
style: update RuboCop configuration for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,100 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
 #   Enabled: false
+# Omakase Ruby styling for Rails
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.3
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/Documentation:
+  Enabled: false
+
+RSpec/SubjectStub:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/FirstArgumentIndentation:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstArrayElementIndentation:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Layout/BeginEndAlignment:
+  Enabled: false
+
+Layout/ArrayAlignment:
+  Enabled: false
+
+Layout/ElseAlignment:
+  Enabled: false
+
+Layout/EndAlignment:
+  Enabled: false
+
+Layout/LineLength:
+  Enabled: false
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  EnforcedStyle: no_space
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Max: 10
+
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/BeforeAfterAll:
+  Enabled: false
+
+RSpec/SpecFilePathFormat:
+  Enabled: true
+  Exclude:
+    - 'spec/acceptance/**/*_spec.rb'
+
+RSpec/DescribeClass:
+  Enabled: true
+  Exclude:
+    - 'spec/acceptance/**/*_spec.rb'
+
+RSpec/MultipleExpectations:
+  Enabled: true
+  Exclude:
+    - 'spec/acceptance/**/*_spec.rb'
+
+plugins:
+  - rubocop-rake
+  - rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ group :development, :test do
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 
+  gem "rubocop-rake", "~> 0.7.1", require: false
+  gem "rubocop-rspec", "~> 3.6", require: false
+
   gem "rspec", "~> 3.13"
   gem "rspec-rails", "~> 8.0.0"
   gem "testcontainers", "~> 0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,12 @@ GEM
       rubocop (>= 1.72)
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
+    rubocop-rspec (3.6.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     rubyzip (2.4.1)
@@ -469,6 +475,8 @@ DEPENDENCIES
   rspec (~> 3.13)
   rspec-rails (~> 8.0.0)
   rubocop-rails-omakase
+  rubocop-rake (~> 0.7.1)
+  rubocop-rspec (~> 3.6)
   solid_cable
   solid_cache
   solid_queue

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
   config.logger = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
@@ -77,7 +77,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [ :id ]
+  config.active_record.attributes_for_inspect = [:id]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -4,6 +4,6 @@ gem "rack-cors"
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins "*"
-    resource "/assets/*", headers: :any, methods: [ :get, :options ]
+    resource "/assets/*", headers: :any, methods: [:get, :options]
   end
 end

--- a/db/migrate/20250504143649_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250504143649_create_active_storage_tables.active_storage.rb
@@ -19,7 +19,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments, id: primary_key_type do |t|
@@ -33,7 +33,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.index [:record_type, :record_id, :name, :blob_id], name: :index_active_storage_attachments_uniqueness, unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
@@ -41,7 +41,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
       t.belongs_to :blob, null: false, index: false, type: foreign_key_type
       t.string :variation_digest, null: false
 
-      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.index [:blob_id, :variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
@@ -52,6 +52,6 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
       setting = config.options[config.orm][:primary_key_type]
       primary_key_type = setting || :primary_key
       foreign_key_type = setting || :bigint
-      [ primary_key_type, foreign_key_type ]
+      [primary_key_type, foreign_key_type]
     end
 end

--- a/lib/tasks/pagedjs_downloader.rb
+++ b/lib/tasks/pagedjs_downloader.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class PagedjsDownloader
+  def initialize(verbose: false, dry_run: false, out_dir: "app/javascript/vendor")
+    @verbose = verbose
+    @dry_run = dry_run
+    @out_dir = out_dir
+  end
+
+  def download(version = nil)
+    version ||= fetch_latest_version
+    return unless version
+
+    response = download_file(version)
+    return unless response
+
+    save_file(response, version)
+  end
+
+  private
+
+  def fetch_latest_version
+    npm_registry_url = "https://registry.npmjs.org/pagedjs"
+    registry_uri = URI.parse(npm_registry_url)
+    http = create_http_client(registry_uri)
+    registry_response = http.get(registry_uri.path)
+
+    if registry_response.is_a?(Net::HTTPSuccess)
+      package_data = JSON.parse(registry_response.body)
+      version = package_data["dist-tags"]["latest"]
+      puts "Latest version of pagedjs: #{version}" if @verbose
+      version
+    else
+      puts "Failed to get latest version from NPM registry: #{registry_response.code} #{registry_response.message}"
+      nil
+    end
+  rescue => e
+    puts "Error fetching latest version: #{e.class} - #{e.message}"
+    nil
+  end
+
+  def download_file(version)
+    url = "https://unpkg.com/pagedjs@#{version}/dist/paged.esm.js"
+    uri = URI.parse(url)
+    http = create_http_client(uri)
+    request = Net::HTTP::Get.new(uri.request_uri)
+    response = http.request(request)
+    response = follow_redirects(response)
+    if response.is_a?(Net::HTTPSuccess)
+      log_headers(response)
+      response
+    else
+      puts "Failed to download paged.js: #{response.code} #{response.message}"
+      nil
+    end
+  rescue => e
+    puts "Error downloading file: #{e.class} - #{e.message}"
+    nil
+  end
+
+  def follow_redirects(response, max_redirects = 10)
+    redirect_count = 0
+    while response.is_a?(Net::HTTPRedirection) && redirect_count < max_redirects
+      redirect_url = response["location"]
+      redirect_uri = URI.parse(redirect_url)
+      puts "Redirecting to #{redirect_url}" if @verbose
+      http = create_http_client(redirect_uri)
+      request = Net::HTTP::Get.new(redirect_uri.path)
+      response = http.request(request)
+      redirect_count += 1
+    end
+    response
+  end
+
+  def save_file(response, version)
+    file_path = File.join(@out_dir, "paged.esm-#{version}.js")
+    if File.exist?(file_path)
+      backup_path = "#{file_path}.bak"
+      puts "Backing up existing file to #{backup_path}" if @verbose
+      FileUtils.mv(file_path, backup_path) unless @dry_run
+    end
+
+    puts "Would write to #{file_path}" if @dry_run
+    unless @dry_run
+      FileUtils.mkdir_p(File.dirname(file_path))
+      File.open(file_path, "wb") { |file| file.write(response.body) }
+      puts "Paged.js v#{version} downloaded to #{file_path}"
+    end
+  end
+
+  def create_http_client(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == "https")
+    http.open_timeout = 10
+    http.read_timeout = 30
+    http
+  end
+
+  def log_headers(response)
+    return unless @verbose
+    puts "Response headers:"
+    response.each_header { |k, v| puts "  #{k}: #{v}" }
+  end
+end

--- a/lib/tasks/update-pagedjs.rake
+++ b/lib/tasks/update-pagedjs.rake
@@ -4,9 +4,11 @@
 # A rake task to download the newest ESM version of pagedjs from https://unpkg.com/pagedjs/dist/paged.esm.js
 # into the folder vendor/javascript/paged.esm-<version>.js
 
+require_relative "pagedjs_downloader"
+
 namespace :update_pagedjs do
   desc "Download the newest ESM version of pagedjs. Usage: rake update_pagedjs:download[version] VERBOSE=1 DRY_RUN=1 OUT=vendor/javascript"
-  task :download, [ :version ] do |_, args|
+  task :download, [:version] do |_, args|
     require "net/http"
     require "uri"
     require "fileutils"
@@ -14,7 +16,7 @@ namespace :update_pagedjs do
 
     verbose = ENV["VERBOSE"] == "1"
     dry_run = ENV["DRY_RUN"] == "1"
-    out_dir = ENV["OUT"] || "vendor/javascript"
+    out_dir = ENV["OUT"] || "app/javascript/vendor"
     version = args[:version]
 
     begin
@@ -27,109 +29,6 @@ namespace :update_pagedjs do
     rescue SocketError, Timeout::Error => e
       puts "Network error: #{e.class} - #{e.message}"
       exit 1
-    end
-  end
-
-  class PagedjsDownloader
-    def initialize(verbose: false, dry_run: false, out_dir: "vendor/javascript")
-      @verbose = verbose
-      @dry_run = dry_run
-      @out_dir = out_dir
-    end
-
-    def download(version = nil)
-      version ||= fetch_latest_version
-      return unless version
-
-      response = download_file(version)
-      return unless response
-
-      save_file(response, version)
-    end
-
-    private
-
-    def fetch_latest_version
-      npm_registry_url = "https://registry.npmjs.org/pagedjs"
-      registry_uri = URI.parse(npm_registry_url)
-      http = create_http_client(registry_uri)
-      registry_response = http.get(registry_uri.path)
-
-      if registry_response.is_a?(Net::HTTPSuccess)
-        package_data = JSON.parse(registry_response.body)
-        version = package_data["dist-tags"]["latest"]
-        puts "Latest version of pagedjs: #{version}" if @verbose
-        version
-      else
-        puts "Failed to get latest version from NPM registry: #{registry_response.code} #{registry_response.message}"
-        nil
-      end
-    rescue => e
-      puts "Error fetching latest version: #{e.class} - #{e.message}"
-      nil
-    end
-
-    def download_file(version)
-      url = "https://unpkg.com/pagedjs@#{version}/dist/paged.esm.js"
-      uri = URI.parse(url)
-      http = create_http_client(uri)
-      request = Net::HTTP::Get.new(uri.request_uri)
-      response = http.request(request)
-      response = follow_redirects(response)
-      if response.is_a?(Net::HTTPSuccess)
-        log_headers(response)
-        response
-      else
-        puts "Failed to download paged.js: #{response.code} #{response.message}"
-        nil
-      end
-    rescue => e
-      puts "Error downloading file: #{e.class} - #{e.message}"
-      nil
-    end
-
-    def follow_redirects(response, max_redirects = 10)
-      redirect_count = 0
-      while response.is_a?(Net::HTTPRedirection) && redirect_count < max_redirects
-        redirect_url = response["location"]
-        redirect_uri = URI.parse(redirect_url)
-        puts "Redirecting to #{redirect_url}" if @verbose
-        http = create_http_client(redirect_uri)
-        request = Net::HTTP::Get.new(redirect_uri.path)
-        response = http.request(request)
-        redirect_count += 1
-      end
-      response
-    end
-
-    def save_file(response, version)
-      file_path = File.join(@out_dir, "paged.esm-#{version}.js")
-      if File.exist?(file_path)
-        backup_path = "#{file_path}.bak"
-        puts "Backing up existing file to #{backup_path}" if @verbose
-        FileUtils.mv(file_path, backup_path) unless @dry_run
-      end
-
-      puts "Would write to #{file_path}" if @dry_run
-      unless @dry_run
-        FileUtils.mkdir_p(File.dirname(file_path))
-        File.open(file_path, "wb") { |file| file.write(response.body) }
-        puts "Paged.js v#{version} downloaded to #{file_path}"
-      end
-    end
-
-    def create_http_client(uri)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = (uri.scheme == "https")
-      http.open_timeout = 10
-      http.read_timeout = 30
-      http
-    end
-
-    def log_headers(response)
-      return unless @verbose
-      puts "Response headers:"
-      response.each_header { |k, v| puts "  #{k}: #{v}" }
     end
   end
 end

--- a/spec/support/default_dirs_helper.rb
+++ b/spec/support/default_dirs_helper.rb
@@ -15,7 +15,7 @@ module DefaultDirsHelper
   end
 
   def random_tmp_dir(*dirs, prefix: "tmp_")
-    all_dirs = [ tmp_dir ] + (dirs || []).compact
+    all_dirs = [tmp_dir] + (dirs || []).compact
 
     File.join(*all_dirs, "#{prefix}#{SecureRandom.hex(8)}")
   end


### PR DESCRIPTION
Refines the RuboCop settings to enforce double quotes for string literals and disables several layout rules for improved code style consistency. Additionally, it adds new gems for RSpec and Rake support in the development environment.