### PR TITLE
feat: add example for generating encrypted PDFs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
       stringio
     puma (6.6.0)
       nio4r (~> 2.0)
-    qpdf_ruby (0.1.0)
+    qpdf_ruby (0.1.1)
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.16)

--- a/app/assets/stylesheets/example_encryption/print.css
+++ b/app/assets/stylesheets/example_encryption/print.css
@@ -1,0 +1,26 @@
+body {
+    font-family: "VG5000", sans-serif;
+    line-height: 1.5;
+    font-size: 16px;
+    letter-spacing: normal;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+@page {
+    size: 210mm 297mm;
+    margin: 30mm 2mm 10mm 2mm;
+
+    @top-left {
+        content: element(runningheader);
+        height: 100%;
+        width: 100%;
+    }
+
+    @bottom-left {
+        content: element(runningfooter);
+        height: 100%;
+        width: 100%;
+    }
+}
+

--- a/app/controllers/example_encryption_controller.rb
+++ b/app/controllers/example_encryption_controller.rb
@@ -1,0 +1,39 @@
+class ExampleEncryptionController < ApplicationController
+  def show
+    respond_to do |format|
+      format.html
+      format.pdf {
+        render pdf: "example_encryption",
+               callbacks: {
+                 after_print: ->(url_or_content, browser_tab, binary_pdf_content, filename, controller) {
+                   after_print_callback(url_or_content, browser_tab, binary_pdf_content, filename, controller)
+                 }
+               }
+      }
+    end
+  end
+
+  private
+
+  def after_print_callback(_url_or_content, _browser_tab, binary_pdf_content, _filename, _controller)
+    raise "QpdfRuby::Document is not available. Please install the gem qpdf_ruby to add password." unless defined?(QpdfRuby::Document)
+
+    doc = QpdfRuby::Document.from_memory(binary_pdf_content, "")
+
+    doc.encrypt(
+      user_pw: "12345678",
+      owner_pw: "password",
+      encryption_revision: QpdfRuby::ENCRYPTION_REVISION_AES_256U,
+      allow_print: QpdfRuby::PRINT_LOW,
+      allow_modify: true,
+      allow_extract: false,
+      accessibility: true,
+      assemble: false,
+      annotate_and_form: false,
+      form_filling: false,
+      encrypt_metadata: true,
+      use_aes: true
+    )
+    doc.to_memory
+  end
+end

--- a/app/controllers/example_routes_controller.rb
+++ b/app/controllers/example_routes_controller.rb
@@ -57,6 +57,14 @@ class ExampleRoutesController < ApplicationController
         description: "This page demonstrates how to generate a PDF with accessibility features using Paged.js and post-processing with xmp_toolkit_ruby and qpdf_ruby. The quirky html is needed to get a good tagged PDF.",
         url: example_accessibility_url,
         pdf_url: example_accessibility_url(format: :pdf)
+      },
+      {
+        title: "Encryption Example",
+        controller: "ExampleEncryptionController",
+        action: "show",
+        description: "This page demonstrates how to generate a password-protected PDF using qpdf_ruby for postprocessing. The user password is '12345678' and the owner password is 'password'.",
+        url: example_encryption_url,
+        pdf_url: example_encryption_url(format: :pdf)
       }
     ]
   end

--- a/app/helpers/example_encryption_helper.rb
+++ b/app/helpers/example_encryption_helper.rb
@@ -1,0 +1,2 @@
+module ExampleEncryptionHelper
+end

--- a/app/views/example_encryption/show.html.erb
+++ b/app/views/example_encryption/show.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title, "Generate a PDF with passwords" %>
+
+<div
+  class="interface-bar-bottom"
+  data-controller="pagedjs"
+  data-pagedjs-stylesheets-value="<%= ["example_encryption/print"].map { |stylesheet| asset_url(stylesheet, type: :stylesheet) }.to_json %>"
+  data-pagedjs-clear-content-value="false"
+>
+  <div data-pagedjs-target="rendered"></div>
+
+  <template data-pagedjs-target="content">
+    <div class="container my-5">
+      <div class="row justify-content-center">
+        <div class="col-md-8 col-lg-6">
+          <div class="card shadow">
+            <div class="card-header bg-primary text-white">
+              <h2 class="mb-0">PDF Encryption Example</h2>
+            </div>
+            <div class="card-body">
+              <p>
+                This example demonstrates how to generate a password-protected PDF. The PDF will require a password to
+                open
+                or modify, depending on the permissions you set.
+              </p>
+              <dl class="row">
+                <dt class="col-sm-4">Owner Password:</dt>
+                <dd class="col-sm-8"><code>password</code></dd>
+
+                <dt class="col-sm-4">User Password:</dt>
+                <dd class="col-sm-8"><code>12345678</code></dd>
+              </dl>
+              <div class="alert alert-info mt-4">
+                <strong>Note:</strong> The owner password allows full access, while the user password may restrict
+                certain
+                actions (like printing or editing).
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get "example_async_pdf/generate", as: :example_async_pdf_generate
   get "example_async_pdf/progress/:id", to: "example_async_pdf#progress", as: :example_async_pdf_progress
   get "example_accessibility/show", as: :example_accessibility
+  get "example_encryption/show", as: :example_encryption
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/spec/acceptance/user_can_call_bookaccessibility_example_spec.rb
+++ b/spec/acceptance/user_can_call_bookaccessibility_example_spec.rb
@@ -85,6 +85,12 @@ RSpec.feature "As a developer, I want to an example of accessible pdf's", :chrom
           expected_date_node.content = "DUMMY_DATE" if expected_date_node
         end
 
+        metadata_date_node = actual_xml.at_xpath("//pdf:Producer", "pdf" => XmpToolkitRuby::Namespaces::XMP_NS_PDF)
+        metadata_date_node.content = "DUMMY_PRODUCER" if metadata_date_node
+
+        expected_date_node = expected_xml.at_xpath("//pdf:Producer", "pdf" => XmpToolkitRuby::Namespaces::XMP_NS_PDF)
+        expected_date_node.content = "DUMMY_PRODUCER" if expected_date_node
+
         expect(actual_xml.to_s).to eq(expected_xml.to_s)
       end
 
@@ -97,6 +103,10 @@ RSpec.feature "As a developer, I want to an example of accessible pdf's", :chrom
 
         actual_xml = Nokogiri::XML(actual_structure, &:noblanks)
         expected_xml = Nokogiri::XML(expected_structure, &:noblanks)
+
+        [actual_xml, expected_xml].each do |xml|
+          xml.xpath('//@ID').remove
+        end
 
         expect(actual_xml.to_s).to eq(expected_xml.to_s)
       end

--- a/spec/acceptance/user_can_call_encryption_example_spec.rb
+++ b/spec/acceptance/user_can_call_encryption_example_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.feature "As a developer, I want to an example of encrypted pdf's", :chromedriver, :pdf, type: :request do
+  scenario "Rendering a PDF using the encryption example" do
+    when_ "I visit the PDF version of a report" do
+      before do
+        @response = get_pdf_response "example_encryption/show.pdf"
+      end
+
+      then_ "I receive a successful HTTP response" do
+        expect(@response.code).to eq("200")
+      end
+
+      and_ "I receive a PDF file in response" do
+        expect(@response['Content-Type']).to eq("application/pdf")
+      end
+
+      and_ "the PDF contains the expected number of pages" do
+        expected_page_count = 1
+
+        with_pdf_debug(unencrypted_pdf("password")) do |pdf_data|
+          expect(pdf_data).to have_pdf_page_count(expected_page_count)
+        end
+      end
+
+      and_ "the disposition header is set to attachment" do
+        expect(@response['Content-Disposition']).to start_with('inline; filename="example_encryption.pdf"')
+      end
+
+      and_ "the PDF contains the expected content" do
+        expect(unencrypted_pdf("password")).to contains_pdf_text("PDF Encryption Example This example demonstrates how to generate a password-protected PDF").at_page(1)
+      end
+
+      and_ "the PDF is encrypted with the correct password" do
+        expect do
+          unencrypted_pdf "wrong_password"
+        end.to raise_error(QpdfRuby::Error, /invalid password/)
+      end
+
+      and_ "the PDF can be decrypted with the user password" do
+        decrypted_pdf = unencrypted_pdf("12345678")
+
+        with_pdf_debug(decrypted_pdf) do |pdf_data|
+          expect(pdf_data).to contains_pdf_text("PDF Encryption Example This example demonstrates how to generate a password-protected PDF").at_page(1)
+        end
+      end
+    end
+  end
+
+  def unencrypted_pdf(password)
+    doc = QpdfRuby::Document.from_memory(@response.body, password)
+    doc.encrypt(
+      user_pw: "",
+      owner_pw: "",
+      encryption_revision: QpdfRuby::ENCRYPTION_REVISION_AES_256U,
+      allow_print: QpdfRuby::PRINT_LOW
+    )
+    doc.to_memory
+  end
+end

--- a/spec/fixtures/example_accessibility_structure.xml
+++ b/spec/fixtures/example_accessibility_structure.xml
@@ -155,21 +155,21 @@
               </H2>
               <Table obj="189 0">
                 <TR obj="142 0">
-                  <TH obj="72 0" ID="node00000233">
+                  <TH obj="72 0" ID="node00000227">
                     <P obj="141 0">
                       <NonStruct obj="104 0" Page="2">
                         [MCID: 3]
                       </NonStruct>
                     </P>
                   </TH>
-                  <TH obj="73 0" ID="node00000235">
+                  <TH obj="73 0" ID="node00000229">
                     <P obj="143 0">
                       <NonStruct obj="105 0" Page="2">
                         [MCID: 4]
                       </NonStruct>
                     </P>
                   </TH>
-                  <TH obj="74 0" ID="node00000237">
+                  <TH obj="74 0" ID="node00000231">
                     <P obj="144 0">
                       <NonStruct obj="106 0" Page="2">
                         [MCID: 5]


### PR DESCRIPTION
Introduces the ExampleEncryptionController to demonstrate how to create password-protected PDFs using the qpdf_ruby gem. The implementation includes user and owner passwords, along with a corresponding view and route for accessing the example.